### PR TITLE
dtrace-provider (used by restify) is not compatible with latest Node …

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "nodemailer": "^1.3.0",
     "nodemailer-smtp-transport": "^0.1.13",
-    "restify": "^2.6.3",
+    "restify": "^4.1.1",
     "twilio": "^1.6.0"
   }
 }


### PR DESCRIPTION
…for the previously tagged version.
